### PR TITLE
Change Node.js runtime version from 12 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Redocly Problem Matchers
 description: Setup Problem Matchers for redocly/openapi-cli.
 runs:
-  using: node12
+  using: node20
   main: index.js
 branding:
   color: blue


### PR DESCRIPTION
As `node12` is deprecated and already forced to `node16`. I believe once this is merged it would also require a new release in order to have a new version available.

This PR resolves waning such as:
> [Open Api Spec](https://example.org)
The following actions uses node12 which is deprecated and will be forced to run on node16: r7kamura/redocly-problem-matchers@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/