### PR TITLE
Change Node.js runtime version from 20 to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: r7kamura/redocly-problem-matchers@v1

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Redocly Problem Matchers
 description: Setup Problem Matchers for redocly/openapi-cli.
 runs:
-  using: node20
+  using: node24
   main: index.js
 branding:
   color: blue


### PR DESCRIPTION
Since `node20` is already deprecated and `node24` is advised to be used, this PR addresses the update for that.

Running the actions is now giving the following warning:
<img width="1109" height="165" alt="Screenshot 2026-04-01 at 12 23 21" src="https://github.com/user-attachments/assets/b9e2572b-5fd3-4d41-84cf-fca7876f103f" />
The link in the message: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I have also updated the example because it also relies on the supported versions of node.